### PR TITLE
Add SQL support for accounts

### DIFF
--- a/accounts.json
+++ b/accounts.json
@@ -1,8 +1,0 @@
-{
-    "police":1000000,
-    "ambulance":0,
-    "realestate":0,
-    "taxi":0,
-    "cardealer":0,
-    "mechanic":0
-}

--- a/qbbossmenu.sql
+++ b/qbbossmenu.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `bossmenu_accounts` (
+    `id` int(11) NOT NULL AUTO_INCREMENT,
+    `account` text NOT NULL,
+    `money` text NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+INSERT INTO `bossmenu_accounts`(`account`, `money`) VALUES('police', '1000000');
+INSERT INTO `bossmenu_accounts`(`account`, `money`) VALUES('ambulance', '0');
+INSERT INTO `bossmenu_accounts`(`account`, `money`) VALUES('realestate', '0');
+INSERT INTO `bossmenu_accounts`(`account`, `money`) VALUES('taxi', '0');
+INSERT INTO `bossmenu_accounts`(`account`, `money`) VALUES('cardealer', '0');
+INSERT INTO `bossmenu_accounts`(`account`, `money`) VALUES('mechanic', '0');

--- a/server.lua
+++ b/server.lua
@@ -33,7 +33,7 @@ function UpdateAccountMoney(account, money)
 end
 
 -- Withdraw Money
-RegisterServerEvent("qb-bossmenu:server:withdrawMoney")
+RegisterNetEvent("qb-bossmenu:server:withdrawMoney")
 AddEventHandler("qb-bossmenu:server:withdrawMoney", function(amount)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
@@ -55,7 +55,7 @@ AddEventHandler("qb-bossmenu:server:withdrawMoney", function(amount)
 end)
 
 -- Deposit Money
-RegisterServerEvent("qb-bossmenu:server:depositMoney")
+RegisterNetEvent("qb-bossmenu:server:depositMoney")
 AddEventHandler("qb-bossmenu:server:depositMoney", function(amount)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
@@ -75,7 +75,7 @@ AddEventHandler("qb-bossmenu:server:depositMoney", function(amount)
     TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Deposit Money', "Successfully deposited $" .. amount .. ' (' .. job .. ')', src)
 end)
 
-RegisterServerEvent("qb-bossmenu:server:addAccountMoney")
+RegisterNetEvent("qb-bossmenu:server:addAccountMoney")
 AddEventHandler("qb-bossmenu:server:addAccountMoney", function(account, amount)
     if not Accounts[account] then
         Accounts[account] = 0
@@ -86,7 +86,7 @@ AddEventHandler("qb-bossmenu:server:addAccountMoney", function(account, amount)
     UpdateAccountMoney(job, Accounts[job])
 end)
 
-RegisterServerEvent("qb-bossmenu:server:removeAccountMoney")
+RegisterNetEvent("qb-bossmenu:server:removeAccountMoney")
 AddEventHandler("qb-bossmenu:server:removeAccountMoney", function(account, amount)
     if not Accounts[account] then
         Accounts[account] = 0
@@ -132,7 +132,7 @@ QBCore.Functions.CreateCallback('qb-bossmenu:server:GetEmployees', function(sour
 end)
 
 -- Grade Change
-RegisterServerEvent('qb-bossmenu:server:updateGrade')
+RegisterNetEvent('qb-bossmenu:server:updateGrade')
 AddEventHandler('qb-bossmenu:server:updateGrade', function(target, grade)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
@@ -160,7 +160,7 @@ AddEventHandler('qb-bossmenu:server:updateGrade', function(target, grade)
 end)
 
 -- Fire Employee
-RegisterServerEvent('qb-bossmenu:server:fireEmployee')
+RegisterNetEvent('qb-bossmenu:server:fireEmployee')
 AddEventHandler('qb-bossmenu:server:fireEmployee', function(target)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
@@ -196,7 +196,7 @@ AddEventHandler('qb-bossmenu:server:fireEmployee', function(target)
 end)
 
 -- Recruit Player
-RegisterServerEvent('qb-bossmenu:server:giveJob')
+RegisterNetEvent('qb-bossmenu:server:giveJob')
 AddEventHandler('qb-bossmenu:server:giveJob', function(recruit)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)


### PR DESCRIPTION
This commit removes the use of the 'accounts.json' file and replaces it with SQL support. This PR was made because of a suggestion in the QBCore Discord from user 'Hyper#7533' to move the accounts.json data into a database table which as of the time this PR was made, had an overwhelming positive rating of 45-4.

I have tested these changes using my own private QBCore testing server created using the TxAdmin recipe for QBCore. I tested depositing and withdrawing money from the 'police' account, which worked as expected, with no obvious issues.

This PR also contains a really minor change to the server sided event registration, of which i simply removed the deprecated 'RegisterServerEvent' function.