### PR TITLE
Promote/Fire those only higher/lower than grade

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -40,11 +40,11 @@ AddEventHandler("qb-bossmenu:server:withdrawMoney", function(amount)
         Accounts[job] = Accounts[job] - amount
         Player.Functions.AddMoney("cash", amount)
     else
-        TriggerClientEvent('QBCore:Notify', src, 'Not Enough Money', 'error')
+        TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="Not Enough Money"}, 'error')
         return
     end
     SaveResourceFile(GetCurrentResourceName(), "./accounts.json", json.encode(Accounts), -1)
-    TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Withdraw Money', "Successfully withdrawn $" .. amount .. ' (' .. job .. ')', src)
+    TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Withdraw Money', 'lightgreen', Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname .. ' successfully withdrew $' .. amount .. ' (' .. job .. ')', false)
 end)
 
 -- Deposit Money
@@ -61,11 +61,11 @@ AddEventHandler("qb-bossmenu:server:depositMoney", function(amount)
     if Player.Functions.RemoveMoney("cash", amount) then
         Accounts[job] = Accounts[job] + amount
     else
-        TriggerClientEvent('QBCore:Notify', src, 'Not Enough Money', "error")
+        TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="Not Enough Money"}, "error")
         return
     end
     SaveResourceFile(GetCurrentResourceName(), "./accounts.json", json.encode(Accounts), -1)
-    TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Deposit Money', "Successfully deposited $" .. amount .. ' (' .. job .. ')', src)
+    TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Deposit Money', 'lightgreen', "Successfully deposited $" .. amount .. ' (' .. job .. ')', false)
 end)
 
 RegisterServerEvent("qb-bossmenu:server:addAccountMoney")
@@ -107,15 +107,17 @@ QBCore.Functions.CreateCallback('qb-bossmenu:server:GetEmployees', function(sour
 
             if isOnline then
                 employees[#employees+1] = {
-                    src = isOnline.PlayerData.citizenid,
+                    empSource = isOnline.PlayerData.citizenid,
                     grade = isOnline.PlayerData.job.grade,
+                    level = isOnline.PlayerData.job.grade.level,
                     isboss = isOnline.PlayerData.job.isboss,
                     name = isOnline.PlayerData.charinfo.firstname .. ' ' .. isOnline.PlayerData.charinfo.lastname
                 }
             else
                 employees[#employees+1] = {
-                    src = value.citizenid,
+                    empSource = value.citizenid,
                     grade =  json.decode(value.job).grade,
+                    level = json.decode(value.job).grade.level,
                     isboss = json.decode(value.job).isboss,
                     name = json.decode(value.charinfo).firstname .. ' ' .. json.decode(value.charinfo).lastname
                 }
@@ -131,25 +133,38 @@ AddEventHandler('qb-bossmenu:server:updateGrade', function(target, grade)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local Employee = QBCore.Functions.GetPlayerByCitizenId(target)
-    if Employee then
-        if Employee.Functions.SetJob(Player.PlayerData.job.name, grade) then
-            TriggerClientEvent('QBCore:Notify', src, "Grade Changed Successfully!", "success")
-            TriggerClientEvent('QBCore:Notify', Employee.PlayerData.source, "Your Job Grade Is Now [" ..grade.."].", "success")
+    if grade == nil then
+        TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="Invalid grade. Numbers only, with 0 being the lowest grade. What is this, amateur hour?"}, "error", 6000)
+        return
+    end
+    if Player.PlayerData.job.grade.level >= grade and grade <= Player.PlayerData.job.grade.level then
+        if Employee then
+            if Employee.Functions.SetJob(Player.PlayerData.job.name, grade) then
+                TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Job Grade Changed', 'lightgreen', Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname .. ' changed grade to ' .. grade .. ' for ' .. Employee.PlayerData.charinfo.firstname .. ' ' .. Employee.PlayerData.charinfo.lastname .. ' (' .. Player.PlayerData.job.name .. ')', false)
+                TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="Grade Changed Successfully!"}, "success")
+                TriggerClientEvent('QBCore:Notify', Employee.PlayerData.source, {text="Human Resources", caption="Your new job grade is now [" ..grade.."]."}, "success")
+            else
+                TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="Grade Does Not Exist"}, "error")
+            end
         else
-            TriggerClientEvent('QBCore:Notify', src, "Grade Does Not Exist", "error")
+            local playerJob = '%' .. Player.PlayerData.job.name .. '%'
+            local result = exports.oxmysql:scalarSync('SELECT job FROM players WHERE citizenid = ? AND job LIKE ?', {target, playerJob})
+            if result then
+                jobFinal = checkJob(Player.PlayerData.job.name, grade)
+                if jobFinal ~= false then
+                    TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Job Grade Changed', 'lightgreen', Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname .. ' changed grade to ' .. jobFinal.grade.name .. ' for '  .. target .. ' (' .. Player.PlayerData.job.name .. ')', false)
+                    TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="Grade Changed Successfully!"}, "success")
+                    exports.oxmysql:execute('UPDATE players SET job = ? WHERE citizenid = ?', { json.encode(jobFinal), target })
+                else
+                    TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="Invalid grade. Numbers only, with 0 being the lowest grade. What is this, amateur hour?"}, "error", 6000)
+                end
+            else
+                TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="This person is not on your payroll"}, "error", 5000)
+            end
         end
     else
-        local player = exports.oxmysql:executeSync('SELECT * FROM players WHERE citizenid = ? LIMIT 1', { target })
-        if player[1] ~= nil then
-            Employee = player[1]
-            local job = QBCore.Shared.Jobs[Player.PlayerData.job.name]
-            local employeejob = json.decode(Employee.job)
-            employeejob.grade = job.grades[data.grade]
-            exports.oxmysql:execute('UPDATE players SET job = ? WHERE citizenid = ?', { json.encode(employeejob), target })
-            TriggerClientEvent('QBCore:Notify', src, "Grade Changed Successfully!", "success")
-        else
-            TriggerClientEvent('QBCore:Notify', src, "Player Does Not Exist", "error")
-        end
+        TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Unfair Job Change', 'lightgreen', Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname .. ' tried to changed grade to ' .. checkJob(Player.PlayerData.job.name, grade).grade.name .. ' ('.. grade ..') for '  .. target .. ' (' .. Player.PlayerData.job.name .. ') but failed because they are lower rank than the person or are trying to give themselves a promotion.', true)
+        TriggerClientEvent('QBCore:Notify', src, {text="Human Resources",caption="You are not authorized to do this. This has been reported."}, "error", 8000)
     end
 end)
 
@@ -160,32 +175,37 @@ AddEventHandler('qb-bossmenu:server:fireEmployee', function(target)
     local Player = QBCore.Functions.GetPlayer(src)
     local Employee = QBCore.Functions.GetPlayerByCitizenId(target)
     if Employee then
-        if Employee.Functions.SetJob("unemployed", '0') then
-            TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Job Fire', "Successfully fired " .. GetPlayerName(Employee.PlayerData.source) .. ' (' .. Player.PlayerData.job.name .. ')', src)
-            TriggerClientEvent('QBCore:Notify', src, "Fired successfully!", "success")
-            TriggerClientEvent('QBCore:Notify', Employee.PlayerData.source , "You Were Fired", "error")
+        if Player.PlayerData.job.grade.level >= Employee.PlayerData.job.grade.level then
+            if Employee.Functions.SetJob("unemployed", '0') then
+                TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Job Fire', 'red', Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname .. ' successfully fired ' .. Employee.PlayerData.charinfo.firstname .. ' ' .. Employee.PlayerData.charinfo.lastname .. ' (' .. Player.PlayerData.job.name .. ')', false)
+                TriggerClientEvent('QBCore:Notify', src, {text="Human Resources",caption="You have fired your employee. We will be sending the records to " .. Player.PlayerData.job.label .. " and government."}, "error", 5000)
+                TriggerClientEvent('QBCore:Notify', Employee.PlayerData.source , {text="Human Resources", caption="You Were Fired. Please look for a new job at the courthouse (City Services) and pick up your belongings."}, "error", 10000)
+            else
+                TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="Mail in a video raffle ticket with full details regarding this error."}, "error")
+            end
         else
-            TriggerClientEvent('QBCore:Notify', src, "Contact Server Developer", "error")
+            TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Unfair Firing', 'red', Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname .. ' tried to fire ('.. target .. ') at (' .. Player.PlayerData.job.name .. ') but failed because they are lower rank than the person. Something amiss is afoot.', true)
+            TriggerClientEvent('QBCore:Notify', src, {text="Human Resources",caption="You are not authorized to do this. This has been reported to " .. Player.PlayerData.job.label .. " and government."}, "error", 15000)
         end
     else
-        local player = exports.oxmysql:executeSync('SELECT * FROM players WHERE citizenid = ? LIMIT 1', { target })
-        if player[1] ~= nil then
-            Employee = player[1]
-            local job = {}
-            job.name = "unemployed"
-            job.label = "Unemployed"
-            job.payment = 10
-            job.onduty = true
-            job.isboss = false
-            job.grade = {}
-            job.grade.name = nil
-            job.grade.level = 0
-            exports.oxmysql:execute('UPDATE players SET job = ? WHERE citizenid = ?', { json.encode(job), target })
-            TriggerClientEvent('QBCore:Notify', src, "Fired successfully!", "success")
-            TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Fire', "Successfully fired " .. data.source .. ' (' .. Player.PlayerData.job.name .. ')', src)
+        local playerJob = '%' .. Player.PlayerData.job.name .. '%'
+        local result = exports.oxmysql:scalarSync('SELECT job FROM players WHERE citizenid = ? AND job LIKE ?', {target, playerJob})
+        if result then
+            jobFinal = checkJob('unemployed', 0)
+            if jobFinal ~= false then
+                exports.oxmysql:execute('UPDATE players SET job = ? WHERE citizenid = ?', { json.encode(jobFinal), target })
+                TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Fired Employee', 'red', Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname .. ' fired ('.. target .. ') at (' .. Player.PlayerData.job.name .. ')', false)
+                TriggerClientEvent('QBCore:Notify', src, {text="Human Resources",caption="You have fired your employee. We will be sending the records to " .. Player.PlayerData.job.label .. " and government."}, "error", 5000)
+            else
+                TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="Something failed. Did you try turning it off and on again?"}, "error")
+            end
         else
-            TriggerClientEvent('QBCore:Notify', src, "Player Does Not Exist", "error")
+            TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="This person is not on your payroll."}, "error", 4000)
         end
+
+        
+            
+       
     end
 end)
 
@@ -195,11 +215,38 @@ AddEventHandler('qb-bossmenu:server:giveJob', function(recruit)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     local Target = QBCore.Functions.GetPlayer(recruit)
-    if Player.PlayerData.job.isboss == true then
+    if Player.PlayerData.job.isboss == true and (Target.PlayerData.job.name == 'unemployed' or Target.PlayerData.job.name == 'garbage' or Target.PlayerData.job.name == 'taxi' or Target.PlayerData.job.name == 'reporter' or Target.PlayerData.job.name == 'trucker' or Target.PlayerData.job.name == 'tow' or Target.PlayerData.job.name == 'vineyard' or Target.PlayerData.job.name == 'hotdog' or Target.PlayerData.job.name == nil) then
         if Target and Target.Functions.SetJob(Player.PlayerData.job.name, 0) then
-            TriggerClientEvent('QBCore:Notify', src, "You Recruited " .. (Target.PlayerData.charinfo.firstname .. ' ' .. Target.PlayerData.charinfo.lastname) .. " To " .. Player.PlayerData.job.label .. "", "success")
-            TriggerClientEvent('QBCore:Notify', Target.PlayerData.source , "You've Been Recruited To " .. Player.PlayerData.job.label .. "", "success")
-            TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Recruit', "Successfully recruited " .. (Target.PlayerData.charinfo.firstname .. ' ' .. Target.PlayerData.charinfo.lastname) .. ' (' .. Player.PlayerData.job.name .. ')', src)
+            TriggerClientEvent('QBCore:Notify', src, {text="Human Resources", caption="You Recruited " .. (Target.PlayerData.charinfo.firstname .. ' ' .. Target.PlayerData.charinfo.lastname) .. " To " .. Player.PlayerData.job.label .. ""}, "success")
+            TriggerClientEvent('QBCore:Notify', Target.PlayerData.source , {text="Human Resources", caption="You've Been Recruited To " .. Player.PlayerData.job.label .. "!"}, "success")
+            TriggerEvent('qb-log:server:CreateLog', 'bossmenu', 'Job Recruit', 'yellow', Player.PlayerData.charinfo.firstname .. ' ' .. Player.PlayerData.charinfo.lastname .. ' successfully recruited ' .. Target.PlayerData.charinfo.firstname .. ' ' .. Target.PlayerData.charinfo.lastname .. ' (' .. Player.PlayerData.job.name .. ')', false)
         end
     end
 end)
+
+-- Functions
+function checkJob(jobName, grade)
+    job = {}
+    grade = tostring(grade) or '0'
+    if QBCore.Shared.Jobs[jobName] then
+        job.name = jobName
+        job.label = QBCore.Shared.Jobs[jobName].label
+        job.onduty = QBCore.Shared.Jobs[jobName].defaultDuty
+            if QBCore.Shared.Jobs[jobName].grades[grade] then
+                local jobgrade = QBCore.Shared.Jobs[jobName].grades[grade]
+                job.grade = {}
+                job.grade.name = jobgrade.name
+                job.grade.level = tonumber(grade)
+                job.payment = jobgrade.payment or 30
+                job.isboss = jobgrade.isboss or false
+            else
+                job.grade = {}
+                job.grade.name = 'Invalid Grade'
+                job.grade.level = 0
+                job.payment = 30
+                job.isboss = false
+            end
+        return job
+    end
+    return false
+end


### PR DESCRIPTION
This change will install additional safeguards to ensure no one tries to exploit the system to gain access to the society funds by promoting themselves or someone else. Also, fixes the current issue where it wipes out the "grade" sub-json in the database for employees when promoting/demoting. Also enhances the logging to provide more useful logs.

Has been runninng in my server for 24 hours with no complaints.